### PR TITLE
Fixed typo in wavelet order exception

### DIFF
--- a/include/rtkDaubechiesWaveletsConvolutionImageFilter.hxx
+++ b/include/rtkDaubechiesWaveletsConvolutionImageFilter.hxx
@@ -147,7 +147,7 @@ DaubechiesWaveletsConvolutionImageFilter<TImage>::GenerateCoefficientsLowpassDec
       coeff.push_back(0.11009943 / itk::Math::sqrt2);
       break;
     default:
-      itkGenericExceptionMacro(<< "In rtkDaubechiesWaveletsConvolutionImageFilter.hxx: Order should be >= 7.");
+      itkGenericExceptionMacro(<< "In rtkDaubechiesWaveletsConvolutionImageFilter.hxx: Order should be <= 7.");
   } // end case(Order)
   return coeff;
 }


### PR DESCRIPTION
Corrected typo of the order of the `DaubechiesWaveletsConvolutionImageFilter` to be smaller or equal to 7, instead of larger